### PR TITLE
Socket ID on error message objects, and better errors when using closed sockets.

### DIFF
--- a/sockets.tcp.js
+++ b/sockets.tcp.js
@@ -82,6 +82,16 @@ exports.connect = function(socketId, peerAddress, peerPort, callback) {
     exec(win, fail, 'ChromeSocketsTcp', 'connect', [socketId, peerAddress, peerPort]);
 };
 
+exports.connect2 = function(socketId, peerAddress, peerPort, callback) {
+    var win = callback && function() {
+        callback(null, 0);
+    };
+    var fail = callback && function(error) {
+        callback(error);
+    };
+    exec(win, fail, 'ChromeSocketsTcp', 'connect', [socketId, peerAddress, peerPort]);
+};
+
 exports.disconnect = function(socketId, callback) {
     exec(callback, null, 'ChromeSocketsTcp', 'disconnect', [socketId]);
 };

--- a/sockets.tcp.js
+++ b/sockets.tcp.js
@@ -82,7 +82,7 @@ exports.connect = function(socketId, peerAddress, peerPort, callback) {
     exec(win, fail, 'ChromeSocketsTcp', 'connect', [socketId, peerAddress, peerPort]);
 };
 
-exports.connect2 = function(socketId, peerAddress, peerPort, callback) {
+exports.connectV2 = function(socketId, peerAddress, peerPort, callback) {
     var win = callback && function() {
         callback(null, 0);
     };
@@ -110,6 +110,20 @@ exports.secure = function(socketId, options, callback) {
     exec(win, fail, 'ChromeSocketsTcp', 'secure', [socketId, options]);
 };
 
+exports.secureV2 = function(socketId, options, callback) {
+    if (typeof options == 'function') {
+        callback = options;
+        options = {};
+    }
+    var win = callback && function() {
+        callback(null, 0);
+    };
+    var fail = callback && function(error) {
+        callback(error);
+    };
+    exec(win, fail, 'ChromeSocketsTcp', 'secure', [socketId, options]);
+};
+
 exports.send = function(socketId, data, callback) {
     var type = Object.prototype.toString.call(data).slice(8, -1);
     if (type != 'ArrayBuffer') {
@@ -128,6 +142,28 @@ exports.send = function(socketId, data, callback) {
             resultCode: error.resultCode
         };
          exports.onReceiveError.fire(error, sendInfo);
+    };
+    if (data.byteLength == 0) {
+      win(0);
+    } else {
+      exec(win, fail, 'ChromeSocketsTcp', 'send', [socketId, data]);
+    }
+};
+
+exports.sendV2 = function(socketId, data, callback) {
+    var type = Object.prototype.toString.call(data).slice(8, -1);
+    if (type != 'ArrayBuffer') {
+        throw new Error('chrome.sockets.tcp.send - data is not an Array Buffer! (Got: ' + type + ')');
+    }
+    var win = callback && function(bytesSent) {
+        var sendInfo = {
+            bytesSent: bytesSent,
+            resultCode: 0
+        };
+        callback(null, sendInfo);
+    };
+    var fail = callback && function(error) {
+         callback(error);
     };
     if (data.byteLength == 0) {
       win(0);

--- a/src/android/ChromeSocketsTcp.java
+++ b/src/android/ChromeSocketsTcp.java
@@ -776,27 +776,30 @@ public class ChromeSocketsTcp extends CordovaPlugin {
     }
 
     boolean connect(String address, int port, CallbackContext connectCallback) throws IOException {
+      if (channel.isConnectionPending()) {
+        channel.finishConnect();
+      }
+
       if (!channel.isOpen()) {
         channel = SocketChannel.open();
         channel.configureBlocking(false);
         setBufferSize();
       }
 
-      boolean connected = false;
       try {
-        connected = channel.connect(new InetSocketAddress(address, port));
+        channel.connect(new InetSocketAddress(address, port));
       } catch (UnresolvedAddressException e) {
         String errorMesssage = e.getMessage() != null ? e.getMessage() : "UnresolvedAddressException occured while connecting to socket";
         connectCallback.error(errorMesssage);
       }
 
-      if (connected) {
+      if (channel.isConnected()) {
         connectCallback.success();
       } else {
         this.connectCallback = connectCallback;
       }
 
-      return connected;
+      return channel.isConnected();
     }
 
     boolean finishConnect() {

--- a/src/ios/ChromeSocketsTcp.m
+++ b/src/ios/ChromeSocketsTcp.m
@@ -422,11 +422,12 @@ NSTimeInterval const PIPE_TO_FILE_PROGRESS_INTERVAL = 0.1;
     }
 }
 
-- (NSDictionary*)buildErrorInfoWithErrorCode:(NSInteger)theErrorCode message:(NSString*)message
+- (NSDictionary*)buildErrorInfoWithErrorCode:(NSInteger)theErrorCode message:(NSString*)message socketId:(NSNumber*)socketId
 {
     return @{
         @"resultCode": [NSNumber numberWithInteger:theErrorCode],
         @"message": message,
+        @"socketId": socketId
     };
 }
 
@@ -479,7 +480,7 @@ NSTimeInterval const PIPE_TO_FILE_PROGRESS_INTERVAL = 0.1;
     ChromeSocketsTcpSocket* socket = _sockets[socketId];
 
     if (socket == nil) {
-        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:[self buildErrorInfoWithErrorCode:ENOTSOCK message:@"Invalid Argument"]] callbackId:command.callbackId];
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:[self buildErrorInfoWithErrorCode:ENOTSOCK message:@"No socket with that ID" socketId:socketId]] callbackId:command.callbackId];
         return;
     }
 
@@ -488,7 +489,7 @@ NSTimeInterval const PIPE_TO_FILE_PROGRESS_INTERVAL = 0.1;
         if (success) {
             [commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
         } else {
-            [commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:[self buildErrorInfoWithErrorCode:[error code] message:[error localizedDescription]]] callbackId:command.callbackId];
+            [commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:[self buildErrorInfoWithErrorCode:[error code] message:[error localizedDescription] socketId:socketId]] callbackId:command.callbackId];
         }
     } copy];
 
@@ -556,7 +557,7 @@ NSTimeInterval const PIPE_TO_FILE_PROGRESS_INTERVAL = 0.1;
     ChromeSocketsTcpSocket* socket = _sockets[socketId];
 
     if (socket == nil) {
-        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:[self buildErrorInfoWithErrorCode:ENOTSOCK message:@"Invalid Argument"]] callbackId:command.callbackId];
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:[self buildErrorInfoWithErrorCode:ENOTSOCK message:@"No socket with that ID" socketId:socketId]] callbackId:command.callbackId];
         return;
     }
 
@@ -592,7 +593,7 @@ NSTimeInterval const PIPE_TO_FILE_PROGRESS_INTERVAL = 0.1;
     ChromeSocketsTcpSocket* socket = _sockets[socketId];
 
     if (socket == nil) {
-        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:[self buildErrorInfoWithErrorCode:ENOTSOCK message:@"Invalid Argument"]] callbackId:command.callbackId];
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:[self buildErrorInfoWithErrorCode:ENOTSOCK message:@"No socket with that ID" socketId:socketId]] callbackId:command.callbackId];
         return;
     }
 
@@ -606,7 +607,7 @@ NSTimeInterval const PIPE_TO_FILE_PROGRESS_INTERVAL = 0.1;
         [socket->_socket writeData:data withTimeout:-1 tag:-1];
 
     } else {
-        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:[self buildErrorInfoWithErrorCode:ENOTCONN message:@"Socket Not Connected"]] callbackId:command.callbackId];
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:[self buildErrorInfoWithErrorCode:ENOTCONN message:@"Socket Not Connected" socketId:socketId]] callbackId:command.callbackId];
     }
 }
 


### PR DESCRIPTION
- feat: added socketId to error messages
- chore: better error messages when trying to use a closed socket

Tested on Android and IOS.
Also not a breaking change, simply adds socketId to the error objects like so:

```
{
   message: 'test',
   resultCode: '-10',
   socketId: 1
}
```